### PR TITLE
adjust for deprecation warning from Cucumber

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,8 +1,8 @@
 <%
 rerun = File.file?('rerun.txt') ? IO.read('rerun.txt') : ""
 rerun_opts = rerun.to_s.strip.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} features" : "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} #{rerun}"
-std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags ~@wip"
+std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --strict --tags 'not @wip'"
 %>
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features
-rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags ~@wip
+rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip'


### PR DESCRIPTION
> <pre>Deprecated: Found tags option '~@wip'. Support for '~@tag' will be
>  removed from the next release of Cucumber. Please use 'not @tag' instead.</pre>